### PR TITLE
Fix Generate Data Error

### DIFF
--- a/src/GenerateDemoData.php
+++ b/src/GenerateDemoData.php
@@ -105,7 +105,7 @@ class GenerateDemoData extends Command
             Carbon::parse($endDate)
         );
         foreach ($period as $date) {
-            $dateRange[] = $date;
+            $dateRange[] = new Carbon($date);
         }
         return $dateRange;
     }

--- a/src/GenerateDemoData.php
+++ b/src/GenerateDemoData.php
@@ -105,7 +105,7 @@ class GenerateDemoData extends Command
             Carbon::parse($endDate)
         );
         foreach ($period as $date) {
-            $dateRange[] = new Carbon($date);
+            $dateRange[] = Carbon::parse($date);
         }
         return $dateRange;
     }


### PR DESCRIPTION
<img width="718" alt="Screen Shot 2023-10-27 at 18 26 12" src="https://github.com/buku-masjid/demo-data/assets/25413225/90129951-2fbb-4885-9d80-590c1790056f">

Assalamualaikum Mas @nafiesl, ketika saya mau mengerjakan Task https://github.com/buku-masjid/buku-masjid/issues/22, saya memerlukan demo-data dan mencoba menjalankan demo-data ini, tetapi saya mendapati issue seperti screenshot diatas, setelah saya telusuri issue nya karena return dari `getDateRange()` itu array of DateTime, bukan array of Carbon. 

Tetapi saya tidak yakin apakah issue ini hanya terjadi di saya atau terjadi juga di yang lain. Jika PR ini memang OK bisa di merge ya Mas, jika tidak, boleh di close aja ya Mas, terimakasih.
